### PR TITLE
Add support to build ARM64 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ sudo: required
 services:
   - docker
 
+jobs:
+  include:
+    - arch: amd64
+      dist: focal
+    - arch: arm64-graviton2
+      group: edge
+      virt: vm
+      dist: focal
+
 before_install:
   - docker build -t journald-2-cloudwatch -f Dockerfile .
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install Python, pip, boto3 and python-systemd.
 RUN BUILD_DEPS="curl python3-dev python3-pip python3-setuptools pkg-config \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,6 @@
 FROM journald-2-cloudwatch
 
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
-RUN pip3 --no-cache-dir install moto coverage coveralls
+RUN pip3 install --upgrade pip
+RUN pip --no-cache-dir install moto coverage coveralls
 ENTRYPOINT ["coverage", "run", "--source=main", "--branch", "-m", "unittest"]


### PR DESCRIPTION
Hi,

**Package Owner:** Pruthvi Teja
**PR change Details:**

**#Patch Details :**
.travis.yml: Update travis file to build and release arm64 images
Dockerfile: Updated debian tag to latest to support arm64.

**#Testing Detail :**
https://travis-ci.com/github/pruthvireddypuresoftware/journald-2-cloudwatch

**#PR Description :**
Here is my commit message : Build and release ARM64 images

**Body of PR :**

**Modified below files:**
**.travis.yml:** Update travis file to build and release arm64 images
**Dockerfile:** Updated debian tag to latest to support arm64.

Signed-off-by: odidev@puresoftware.com.

**#Reviewer:** Madhukar and Shobhit

Thanks,
Pruthvi Teja.